### PR TITLE
gb - bump version to v0.0.3

### DIFF
--- a/argocd/production/company/gb/values.yaml
+++ b/argocd/production/company/gb/values.yaml
@@ -2,4 +2,4 @@ values:
   someKey: someValue
   image:
     repository: someRepo
-    tag: someTag
+    tag: v0.0.3


### PR DESCRIPTION
This PR was created automatically in response to a new SemVer tag. The version has been bumped to v0.0.3.

This PR is done for the `gb` environment.