### PR TITLE
nl - bump version to v0.0.4

### DIFF
--- a/argocd/production/company/nl/values.yaml
+++ b/argocd/production/company/nl/values.yaml
@@ -2,4 +2,4 @@ values:
   someKey: someValue
   image:
     repository: someRepo
-    tag: someTag
+    tag: 0.0.4


### PR DESCRIPTION
This PR was created automatically in response to a new SemVer tag. The version has been bumped to v0.0.4.

This PR is done for the `nl` environment.