### PR TITLE
ci(production-dk): bump version to v0.1.4

### DIFF
--- a/argocd/production/company/dk/version.yaml
+++ b/argocd/production/company/dk/version.yaml
@@ -1,4 +1,4 @@
 image_a: repo/image_a
-image_a_version: 0.0.1
+image_a_version: 0.1.4
 image_b: repo/image_b
-image_b_version: 0.0.1
+image_b_version: 0.1.4


### PR DESCRIPTION
This PR was created automatically in response to a new SemVer tag. The version has been bumped to v0.1.4.

This PR is done for the `production` environment in the 'dk' region.