### PR TITLE
ci(production-nl): bump version to v0.1.6

### DIFF
--- a/argocd/production/company/nl/version.yaml
+++ b/argocd/production/company/nl/version.yaml
@@ -1,4 +1,4 @@
 image_a: repo/image_a
-image_a_version: 0.0.1
+image_a_version: 0.1.6
 image_b: repo/image_b
-image_b_version: 0.0.1
+image_b_version: 0.1.6


### PR DESCRIPTION
This PR was created automatically in response to a new SemVer tag. The version has been bumped to v0.1.6.

This PR is done for the `production` environment in the 'nl' region.